### PR TITLE
Add simple tests for private network

### DIFF
--- a/httptrottle.go
+++ b/httptrottle.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+	"strconv"
 )
 
 // New accept two parameters, max which is the number of maximum accepted requests
@@ -80,20 +81,40 @@ func getIPAdress(r *http.Request, headers []string) string {
 
 func isValidIp(ip string) bool {
 	realIP := net.ParseIP(ip)
-	if !realIP.IsGlobalUnicast() || isPrivateSubnet(ip) {
+	isPrivate, _ := isPrivateSubnet(ip)
+	if !realIP.IsGlobalUnicast() || isPrivate {
 		return false
 	}
 	return true
 }
 
-func isPrivateSubnet(ip string) bool {
-	first := strings.Split(ip, ".")[0]
-
-	if first == "10" || first == "192" || first == "176" {
-		return true
+func isPrivateSubnet(ip string) (bool, error) {
+	var (
+		first, second int
+		err error
+	)
+	first, err = strconv.Atoi(strings.Split(ip, ".")[0])
+	if err != nil {
+		return false, err
+	}
+	second, err = strconv.Atoi(strings.Split(ip, ".")[1])
+	if err != nil {
+		return false, err
 	}
 
-	return false
+	if first == 10 {
+		return true, nil
+	}
+
+	if first == 172 && second >= 16 && second <= 31  {
+		return true, nil
+	}
+
+	if first == 192 && second == 168  {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func limitByIp(l *Limiter, r *http.Request) error {

--- a/httptrottle.go
+++ b/httptrottle.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
-	"strconv"
 )
 
 // New accept two parameters, max which is the number of maximum accepted requests
@@ -93,11 +92,7 @@ func isPrivateSubnet(ip string) (bool, error) {
 		first, second int
 		err error
 	)
-	first, err = strconv.Atoi(strings.Split(ip, ".")[0])
-	if err != nil {
-		return false, err
-	}
-	second, err = strconv.Atoi(strings.Split(ip, ".")[1])
+	_, err = fmt.Sscanf(ip, "%d.%d", &first, &second)
 	if err != nil {
 		return false, err
 	}

--- a/httptrottle_test.go
+++ b/httptrottle_test.go
@@ -21,6 +21,63 @@ func TestNewLimiter(t *testing.T) {
 	}
 }
 
+func TestPrivateClassA(t *testing.T) {
+	ip := "10.0.0.1"
+	if ok, err := isPrivateSubnet(ip); !ok || err != nil {
+		t.Fatalf("Expected private subnet for %s", ip)
+	}
+	ip = "10.255.255.255"
+	if ok, err := isPrivateSubnet(ip); !ok || err != nil  {
+		t.Fatalf("Expected private subnet for %s", ip)
+	}
+	ip = "9.255.255.255"
+	if ok, _ := isPrivateSubnet(ip); ok {
+		t.Fatalf("Unexpected private subnet for %s", ip)
+	}
+	ip = "11.0.0.0"
+	if ok, _ := isPrivateSubnet(ip); ok {
+		t.Fatalf("Unexpected private subnet for %s", ip)
+	}
+}
+
+func TestPrivateClassB(t *testing.T) {
+	ip := "172.16.0.0"
+	if ok, err := isPrivateSubnet(ip); !ok || err != nil  {
+		t.Fatalf("Expected private subnet for %s", ip)
+	}
+	ip = "172.31.255.255"
+	if ok, err := isPrivateSubnet(ip); !ok || err != nil  {
+		t.Fatalf("Expected private subnet for %s", ip)
+	}
+	ip = "172.15.0.0"
+	if ok, _ := isPrivateSubnet(ip); ok {
+		t.Fatalf("Unexpected private subnet for %s", ip)
+	}
+	ip = "172.32.0.0"
+	if ok, _ := isPrivateSubnet(ip); ok {
+		t.Fatalf("Unexpected private subnet for %s", ip)
+	}
+}
+
+func TestPrivateClassC(t *testing.T) {
+	ip := "192.168.0.0"
+	if ok, err := isPrivateSubnet(ip); !ok || err != nil  {
+		t.Fatalf("Expected private subnet for %s", ip)
+	}
+	ip = "192.168.255.255"
+	if ok, err := isPrivateSubnet(ip); !ok || err != nil  {
+		t.Fatalf("Expected private subnet for %s", ip)
+	}
+	ip = "192.167.255.255"
+	if ok, _ :=  isPrivateSubnet(ip); ok {
+		t.Fatalf("Unexpected private subnet for %s", ip)
+	}
+	ip = "192.1689.0.0"
+	if ok, _ := isPrivateSubnet(ip); ok {
+		t.Fatalf("Unexpected private subnet for %s", ip)
+	}
+}
+
 func TestGetIpAddress(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://12.168.0.1", nil)
 	req.RemoteAddr = "12.168.0.1:4390"


### PR DESCRIPTION
The private network detection returns wrong results. I added (somewhat naïve) tests and a new implementation.

__Note:__ Though the new implementation returns an error, the error is discarded in the code, it should better be handled